### PR TITLE
removed confirmation from showpage rental form

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,3 +2,4 @@
 import "@hotwired/turbo-rails"
 import "./controllers"
 import "bootstrap"
+import Swal from 'sweetalert2'

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
     <%= favicon_link_tag asset_path('favicon.png') %>
+    <script src="//cdn.jsdelivr.net/npm/sweetalert2@11"></script>
   </head>
   <body>
     <%= render 'shared/navbar' %>

--- a/app/views/offers/show.html.erb
+++ b/app/views/offers/show.html.erb
@@ -30,7 +30,7 @@
     </div>
     <div class="rental col-3 ms-3 py-3">
       <p class="border-bottom price text-center py-3">¥<%= @offer.price.truncate %></p>
-      <%= simple_form_for([@offer, @rental], html: { class: "form-group"}, data: {turbo_confirm: "Rent this book?"}) do |f| %>
+      <%= simple_form_for([@offer, @rental], html: { class: "form-group"}) do |f| %>
         <%= f.input :duration_start, html5: true %>
         <%= f.input :duration_end, html5: true %>
         <%= f.submit "Rent", class: "rental-button" %>


### PR DESCRIPTION
Removed the confirmation / alert from the show page after pressing rent.
It will now redirect directly to the dashboard instead.