### PR TITLE
Search result cards button now always shows

### DIFF
--- a/app/views/books/search.html.erb
+++ b/app/views/books/search.html.erb
@@ -2,14 +2,16 @@
   <div class="row gx-5 gap-3">
     <% @books.each do |book| %>
       <div class="offer-card-show col-6">
-        <%= image_tag book.cover_url, alt: "text" %>
+        <%= image_tag book.cover_url, alt: "Book Cover" %>
         <div class="h-100 pb-3 d-flex flex-column justify-content-between">
-          <div class="offer-card-show-info">
+          <div class="offer-card-show-info overflow-scroll">
             <h2 class="border-bottom py-3"><%= book.title%></h2>
             <p class="description overflow-hidden"><%= book.year %></p>
             <p><%= book.category %></p>
             <p>By (author) <%= book.author%></p>
-            <p class="description"><%= book.description %></p>
+            <div class="container ">
+              <p class="description"><%= book.description %></p>
+            </div>
           </div>
           <div>
             <%= simple_form_for(book) do |f| %>

--- a/app/views/offers/show.html.erb
+++ b/app/views/offers/show.html.erb
@@ -1,22 +1,7 @@
-<%# <div class="container">
-  <div class="container">
-    <div class="row">
-      <div class="col-8">
-        <div class="container">
-          <img src="https://images-na.ssl-images-amazon.com/images/I/A1fS8mAs8nL.jpg" alt="book-cover">
-        </div>
-        <div class="container">
-        </div>
-      </div>
-      <div class="col-4"></div>
-    </div>
-  </div>
-</div> %>
 <div class="container">
   <div class="row gx-5 justify-content-center">
     <div class="offer-card-show col-8">
       <%= image_tag @offer.book.cover_url, alt: "#{@offer.book.title} cover", class: 'cover' %>
-      <%# <img src="https://images-na.ssl-images-amazon.com/images/I/A1fS8mAs8nL.jpg" alt="book-cover" class="cover"> %>
       <div class="offer-card-show-info">
         <h2 class="border-bottom py-3"><%= @offer.book.title %></h2>
         <p class="description"><%= @offer.book.year %></p>
@@ -55,4 +40,3 @@
       </div>
     </div>
   </div>
-  <%# ¥500 %>


### PR DESCRIPTION
Set overflow to scroll, so the button always shows and scrolls to read any text not visible
<img width="756" alt="Screen Shot 2022-08-18 at 17 57 42" src="https://user-images.githubusercontent.com/76161172/185354875-b21b2fc3-2c62-4001-9908-d293690f437d.png">
.