### PR TITLE
made cards more uniform in how they're displayed

### DIFF
--- a/app/assets/stylesheets/components/_offer_card_show.scss
+++ b/app/assets/stylesheets/components/_offer_card_show.scss
@@ -34,7 +34,7 @@
 }
 
 .offer-card-show .offer-card-show-info {
-  padding: 16px;
+  // padding: 16px;
   flex: 1;
 }
 

--- a/app/views/books/search.html.erb
+++ b/app/views/books/search.html.erb
@@ -1,15 +1,17 @@
-<div class="container">
-  <div class="row gx-5 gap-3">
+<div class="container ">
+  <div class="row gx-5 gap-3 justify-content-center">
     <% @books.each do |book| %>
-      <div class="offer-card-show col-6">
-        <%= image_tag book.cover_url, alt: "Book Cover" %>
-        <div class="h-100 pb-3 d-flex flex-column justify-content-between">
-          <div class="offer-card-show-info overflow-scroll">
+      <div class="offer-card-show col-sm-12 col-lg-8 ">
+        <div class="container">
+          <%= image_tag book.cover_url, alt: "Book Cover" %>
+        </div>
+        <div class="h-100 py-3 ms-3 d-flex flex-column  flex-fill">
+          <div class="offer-card-show-info overflow-scroll ">
             <h2 class="border-bottom py-3"><%= book.title%></h2>
             <p class="description overflow-hidden"><%= book.year %></p>
             <p><%= book.category %></p>
             <p>By (author) <%= book.author%></p>
-            <div class="container ">
+            <div class="container px-0 ">
               <p class="description"><%= book.description %></p>
             </div>
           </div>


### PR DESCRIPTION
<img width="1440" alt="Screen Shot 2022-08-18 at 19 39 26" src="https://user-images.githubusercontent.com/76161172/185375782-2f3891f7-90b1-44d6-804a-428409f6d182.png">

Made it more uniform in how the book cards are displayed.
There is still a border looking thing on the right and bottom of the text section.
This is caused by the 'overflow-scroll' bootstrap class as a place for the scroll to be.
Haven't found a better way to deal with long descriptions yet.

I may try a grid type layout without descriptions later, but for now I think this looks pretty good.